### PR TITLE
docs: fix changelog header to consistent size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 * bump release level to production/stable ([#31](https://github.com/googleapis/python-optimization/issues/31)) ([dd9377f](https://github.com/googleapis/python-optimization/commit/dd9377f24b3e1ffcaee7c23c72872696bbaa6a20))
 
-### [0.1.1](https://github.com/googleapis/python-optimization/compare/v0.1.0...v0.1.1) (2022-04-25)
+## [0.1.1](https://github.com/googleapis/python-optimization/compare/v0.1.0...v0.1.1) (2022-04-25)
 
 
 ### Documentation


### PR DESCRIPTION
There was a minor issue with patch version releases labeled as an H3 header for changelog. Future changelog headers will always be H2 headers but existing entries must manually be fixed. Towards b/231248807.